### PR TITLE
dependencies: Remove and add dependencies

### DIFF
--- a/proxy/cc-proxy.spec-template
+++ b/proxy/cc-proxy.spec-template
@@ -19,11 +19,6 @@ License  : Apache-2.0 GPL-2.0
 Requires: cc-proxy-bin
 Requires: cc-proxy-config
 
-Requires:  clear-containers-image
-Requires:  clear-containers-selinux
-Requires:  qemu-lite
-Requires:  linux-container
-
 %description
 .. contents::
 .. sectnum::

--- a/runtime/cc-runtime.dsc-template
+++ b/runtime/cc-runtime.dsc-template
@@ -12,6 +12,6 @@ DEBTRANSFORM-RELEASE: 1
 
 Package: cc-runtime
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, qemu-lite, clear-containers-image, linux-container
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, qemu-lite, clear-containers-image, linux-container, cc-proxy, cc-shim
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.

--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -18,9 +18,11 @@ License  : Apache-2.0 GPL-2.0
 
 Requires: cc-runtime-bin
 Requires: cc-runtime-config
-Requires: qemu-lite
+%{!?el7:Requires: qemu-lite }
 Requires: clear-containers-image
 Requires: linux-container
+Requires: cc-proxy
+Requires: cc-shim
 
 %description
 .. contents::

--- a/runtime/debian.control-template
+++ b/runtime/debian.control-template
@@ -10,7 +10,7 @@ DEBTRANSFORM-RELEASE: 1
 
 Package: cc-runtime
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, qemu-lite, clear-containers-image, linux-container
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, qemu-lite, clear-containers-image, linux-container, cc-proxy, cc-shim
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
 


### PR DESCRIPTION
  * cc-runtime: Required qemu-lite which is not packaged for RHEL and
  CentOS. This should not be a requeriment for those distributions.

  * cc-proxy: Required clear-containers-selinux which should be an
  optional package for systems with selinux enabled and only by sysadmin
  desition.

  *  cc-runtime did not install cc-proxy and cc-shim when is installed on
  debian based distros.

  Fixes: #6
  Fixes: #7
  Fixes: #10 

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>