### PR TITLE
Update runtime and shim to 3.0.0-alpha.4

### DIFF
--- a/proxy/debian.changelog
+++ b/proxy/debian.changelog
@@ -2,7 +2,7 @@ cc-proxy (3.0.0-alpha.3) stable; urgency=medium
 
   * Update cc-proxy 3.0.0-alpha.3 b73e4a3
 
- -- Erick Cardona <erick.cardona.ruiz@intel.com>  Thu, 06 Jul 2017 11:18:34 -0500
+ -- Erick Cardona <erick.cardona.ruiz@intel.com>  Mon, 24 Jul 2017 12:59:05 -0500
 
 cc-proxy (3.0.0-alpha.2) stable; urgency=medium
 

--- a/runtime/cc-runtime.dsc-template
+++ b/runtime/cc-runtime.dsc-template
@@ -12,13 +12,15 @@ DEBTRANSFORM-RELEASE: 1
 
 Package: cc-runtime
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime-bin, cc-runtime-config
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime-bin, cc-runtime-config, qemu-lite (>= @qemu_lite_version@),
+                          clear-containers-image (>= @cc_image_version@), linux-container (>= @linux_container_version@),
+			  cc-proxy (>= @cc_proxy_version@), cc-shim (>= @cc_shim_version@)
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
 
 Package: cc-runtime-bin
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, qemu-lite, clear-containers-image, linux-container, cc-proxy, cc-shim
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
  This package contain the cc-runtime and the pause binaries.

--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -23,10 +23,10 @@ BuildRequires: git
 Requires: cc-runtime-bin
 Requires: cc-runtime-config
 %{!?el7:Requires: qemu-lite }
-Requires: clear-containers-image
-Requires: linux-container
-Requires: cc-proxy
-Requires: cc-shim
+Requires: clear-containers-image >= @cc_image_version@
+Requires: linux-container >= @linux_container_version@
+Requires: cc-proxy >= @cc_proxy_version@
+Requires: cc-shim >= @cc_shim_version@
 
 %description
 .. contents::

--- a/runtime/debian.changelog
+++ b/runtime/debian.changelog
@@ -1,3 +1,9 @@
+cc-runtime (3.0.0-alpha.4) stable; urgency=medium
+
+  * Update cc-runtime 3.0.0-alpha.4 7e3b6bf
+
+ -- Erick Cardona <erick.cardona.ruiz@intel.com>  Mon, 24 Jul 2017 13:36:16 -0500
+
 cc-runtime (3.0.0-alpha.3) stable; urgency=medium
 
   * Update cc-runtime 3.0.0-alpha.3 6b91207

--- a/runtime/debian.control-template
+++ b/runtime/debian.control-template
@@ -10,13 +10,15 @@ DEBTRANSFORM-RELEASE: 1
 
 Package: cc-runtime
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime-bin, cc-runtime-config
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime-bin, cc-runtime-config, qemu-lite (>= @qemu_lite_version@),
+                            clear-containers-image (>= @cc_image_version@), linux-container (>= @linux_container_version@),
+			    cc-proxy (>= @cc_proxy_version@), cc-shim (>= @cc_shim_version@)
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
 
 Package: cc-runtime-bin
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, qemu-lite, clear-containers-image, linux-container, cc-proxy, cc-shim
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
  This package contain the cc-runtime and the pause binaries.

--- a/runtime/update_runtime.sh
+++ b/runtime/update_runtime.sh
@@ -49,9 +49,30 @@ function changelog_update {
 }
 changelog_update $VERSION
 
-sed -e "s/@VERSION@/$VERSION/g;" -e "s/@GO_VERSION@/$GO_VERSION/g;" cc-runtime.spec-template > cc-runtime.spec
-sed -e "s/@VERSION_DEB_TRANSFORM@/$VERSION_DEB_TRANSFORM/g;" -e "s/@HASH_TAG@/$short_hashtag/g;"  cc-runtime.dsc-template > cc-runtime.dsc
-sed -e "s/@VERSION_DEB_TRANSFORM@/$VERSION_DEB_TRANSFORM/g;" -e "s/@HASH_TAG@/$short_hashtag/g;" debian.control-template > debian.control
+sed -e "s/@VERSION@/$VERSION/" \
+    -e "s/@GO_VERSION@/$GO_VERSION/g;" \
+    -e "s/@cc_proxy_version@/$proxy_obs_fedora_version/" \
+    -e "s/@cc_shim_version@/$shim_obs_fedora_version/" \
+    -e "s/@qemu_lite_version@/$qemu_lite_obs_fedora_version/" \
+    -e "s/@cc_image_version@/$image_obs_fedora_version/" \
+    -e "s/@linux_container_version@/$linux_container_obs_fedora_version/" cc-runtime.spec-template > cc-runtime.spec
+
+sed -e "s/@VERSION_DEB_TRANSFORM@/$VERSION_DEB_TRANSFORM/g;" \
+    -e "s/@HASH_TAG@/$short_hashtag/g;" \
+    -e "s/@cc_proxy_version@/$proxy_obs_ubuntu_version/" \
+    -e "s/@cc_shim_version@/$shim_obs_ubuntu_version/" \
+    -e "s/@qemu_lite_version@/$qemu_lite_obs_ubuntu_version/" \
+    -e "s/@cc_image_version@/$image_obs_ubuntu_version/" \
+    -e "s/@linux_container_version@/$linux_container_obs_ubuntu_version/" cc-runtime.dsc-template > cc-runtime.dsc
+
+sed -e "s/@VERSION_DEB_TRANSFORM@/$VERSION_DEB_TRANSFORM/g;" \
+    -e "s/@HASH_TAG@/$short_hashtag/g;" \
+    -e "s/@cc_proxy_version@/$proxy_obs_ubuntu_version/" \
+    -e "s/@cc_shim_version@/$shim_obs_ubuntu_version/" \
+    -e "s/@qemu_lite_version@/$qemu_lite_obs_ubuntu_version/" \
+    -e "s/@cc_image_version@/$image_obs_ubuntu_version/" \
+    -e "s/@linux_container_version@/$linux_container_obs_ubuntu_version/" debian.control-template > debian.control
+
 sed "s/@VERSION@/$VERSION/g;" _service-template > _service
 
 # Update and package OBS

--- a/shim/debian.changelog
+++ b/shim/debian.changelog
@@ -1,3 +1,9 @@
+cc-shim (3.0.0-alpha.4) stable; urgency=medium
+
+  * Update cc-shim 3.0.0-alpha.4 ab14648
+
+ -- Erick Cardona <erick.cardona.ruiz@intel.com>  Mon, 24 Jul 2017 11:16:40 -0500
+
 cc-shim (3.0.0-alpha.3) stable; urgency=medium
 
   * Update cc-shim 3.0.0-alpha.3 531004e

--- a/versions.txt
+++ b/versions.txt
@@ -1,9 +1,29 @@
 cc_proxy_hash=b73e4a37c3ff01f087ee5efaf1409380810ea4ce
-cc_runtime_hash=6b912075c1febda818d7d2e80f39b8e284095ca3
-cc_shim_hash=531004e5c945307d7db895a81f768c6c0aa81eb8
+cc_runtime_hash=7e3b6bf6634b494e720110f52bb7fbc9e32023a3
+cc_shim_hash=ab14648926c47d7ebb02e0adba3e95ffbd20765e
 cc_proxy_version=3.0.0-alpha.3
-cc_runtime_version=3.0.0-alpha.3
-cc_shim_version=3.0.0-alpha.3
+cc_runtime_version=3.0.0-alpha.4
+cc_shim_version=3.0.0-alpha.4
 clear_vm_kernel_version=4.9.35-76
 clear_vm_image_version=16180
 qemu_lite_version=741f430a960b5b67745670e8270db91aeb083c5f
+
+# OBS package versions
+# Versions matches the ones in the OBS stable release.
+# When making a new release of the runtime, this file
+# should contain the new versions.
+
+# Fedora
+proxy_obs_fedora_version=3.0.0alpha.3+git.b73e4a3-3.1
+shim_obs_fedora_version=3.0.0alpha.4+git.ab14648-2.1
+image_obs_fedora_version=16180-30.1
+selinux_obs_fedora_version=0.1-3.1
+linux_container_obs_fedora_version=4.9.35-66.1
+qemu_lite_obs_fedora_version=2.7.1+git.741f430a96-6.1
+
+# Ubuntu
+proxy_obs_ubuntu_version=3.0.0alpha.3+git.b73e4a3-0+3.1
+shim_obs_ubuntu_version=3.0.0alpha.4+git.ab14648-0+2.1
+image_obs_ubuntu_version=16180-22
+linux_container_obs_ubuntu_version=4.9.35-62
+qemu_lite_obs_ubuntu_version=2.7.1+git.741f430a96-6.1


### PR DESCRIPTION
Update runtime and shim to 3.0.0-alpha.4

- Update runtime and shim to 3.0.0-alplha.4
- Move dependencies to the meta package.

Add runtime dependencies' versions
    
    This commit adds new entries in the versions.txt for indicating the
    versions of the OBS packages in the stable repository. These are
    added to the spec/dsc files in the "Requires" section and in order
    to support the upgrade path when upgrading the runtime.

