### PR TITLE
specs: Fix incompatible licences

### DIFF
--- a/proxy/cc-proxy.spec-template
+++ b/proxy/cc-proxy.spec-template
@@ -21,7 +21,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: pkgconfig(systemd)
 Summary  : No detailed summary available
 Group    : Development/Tools
-License  : Apache-2.0 GPL-2.0
+License  : Apache-2.0
 
 Requires: cc-proxy-bin
 Requires: cc-proxy-config

--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -15,7 +15,7 @@ Source0:   %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Summary  : No detailed summary available
 Group    : Development/Tools
-License  : Apache-2.0 GPL-2.0
+License  : Apache-2.0
 
 BuildRequires: gcc
 BuildRequires: glibc-static

--- a/shim/cc-shim.spec-template
+++ b/shim/cc-shim.spec-template
@@ -14,7 +14,7 @@ BuildRequires: autoconf
 BuildRequires: automake
 Summary  : No detailed summary available
 Group    : Development/Tools
-License  : Apache-2.0 GPL-2.0
+License  : Apache-2.0
 
 Requires: cc-shim-bin
 


### PR DESCRIPTION
spec files for runtime, proxy and shim shows that the files are
Apache-2.0 GPL2.0 which are incorrect because those two licences are
incompatible.

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>