### PR TITLE
CI: Remove user as project approver

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -33,7 +33,6 @@ groups:
   approvers:
     required: 1
     users:
-      - dlespiau
       - erick0z
       - gorozco1
       - grahamwhaley

--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ reviewers:
 - clear-containers
 
 approvers:
-- dlespiau
 - erick0z
 - gorozco1
 - grahamwhaley


### PR DESCRIPTION
Remove user dlespiau as a project approver as he is no longer a core
maintainer.

Fixes #53.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>