### PR TITLE
packaging: remove go from OBS repo

### DIFF
--- a/proxy/_service-template
+++ b/proxy/_service-template
@@ -12,4 +12,14 @@
     <param name="compression">gz</param>
   </service>
  <service name="set_version"/>
+ <service name="download_url">
+    <param name="protocol">https</param>
+    <param name="host">storage.googleapis.com</param>
+    <param name="path">golang/go1.8.3.linux-amd64.tar.gz</param>
+ </service>
+ <service name="verify_file">
+    <param name="file">_service:download_url:go1.8.3.linux-amd64.tar.gz</param>
+    <param name="verifier">sha256</param>
+    <param name="checksum">1862f4c3d3907e59b04a757cfda0ea7aa9ef39274af99a784f5be843c80c6772</param>
+  </service>
 </services>

--- a/proxy/cc-proxy.spec-template
+++ b/proxy/cc-proxy.spec-template
@@ -4,7 +4,7 @@
 %global ORG clearcontainers
 %global PROJECT proxy
 %global IMPORTNAME %{DOMAIN}/%{ORG}/%{PROJECT}
-%global GO_VERSION @GO_VERSION@
+%global GO_VERSION 1.8.3
 
 %if 0%{?suse_version}
 %define LIBEXECDIR %{_libdir}

--- a/proxy/update_proxy.sh
+++ b/proxy/update_proxy.sh
@@ -27,8 +27,6 @@ else
     APIURL=""
 fi
 
-GO_VERSION=${GO_VERSION:-"1.8.3"}
-
 echo "Running: $0 $@"
 echo "Update cc-proxy $VERSION: ${hash_tag:0:7}"
 
@@ -46,7 +44,7 @@ function changelog_update {
     rm debian.changelog-bk
 }
 changelog_update $VERSION
-sed -e "s/@VERSION@/$VERSION/g;" -e "s/@GO_VERSION@/$GO_VERSION/g;" cc-proxy.spec-template > cc-proxy.spec
+sed -e "s/@VERSION@/$VERSION/" cc-proxy.spec-template > cc-proxy.spec
 sed -e "s/@VERSION_DEB_TRANSFORM@/$VERSION_DEB_TRANSFORM/g;" -e "s/@HASH_TAG@/$short_hashtag/g;" cc-proxy.dsc-template > cc-proxy.dsc
 sed -e "s/@VERSION_DEB_TRANSFORM@/$VERSION_DEB_TRANSFORM/g;" -e "s/@HASH_TAG@/$short_hashtag/g;" debian.control-template > debian.control
 sed "s/@VERSION@/$VERSION/g;" _service-template > _service
@@ -74,9 +72,8 @@ then
     [ -f debian.series ] && cp debian.series $TMPDIR || :
     cd $TMPDIR
 
-    if [ ! -e "go${GO_VERSION}.linux-amd64.tar.gz" ]; then
+    if [ -e "go1.8.3.linux-amd64.tar.gz" ]; then
         rm go*.tar.gz
-        curl -OkL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz
     fi
     osc $APIURL addremove
     osc $APIURL commit -m "Update cc-proxy $VERSION: ${hash_tag:0:7}"

--- a/runtime/_service-template
+++ b/runtime/_service-template
@@ -12,4 +12,14 @@
     <param name="compression">gz</param>
   </service>
  <service name="set_version"/>
+ <service name="download_url">
+    <param name="protocol">https</param>
+    <param name="host">storage.googleapis.com</param>
+    <param name="path">golang/go1.8.3.linux-amd64.tar.gz</param>
+ </service>
+ <service name="verify_file">
+    <param name="file">_service:download_url:go1.8.3.linux-amd64.tar.gz</param>
+    <param name="verifier">sha256</param>
+    <param name="checksum">1862f4c3d3907e59b04a757cfda0ea7aa9ef39274af99a784f5be843c80c6772</param>
+  </service>
 </services>

--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -4,7 +4,7 @@
 %global ORG clearcontainers
 %global PROJECT runtime
 %global IMPORTNAME %{DOMAIN}/%{ORG}/%{PROJECT}
-%global GO_VERSION @GO_VERSION@
+%global GO_VERSION 1.8.3
 
 %undefine _missing_build_ids_terminate_build
 %define  debug_package %{nil}

--- a/runtime/debian.rules
+++ b/runtime/debian.rules
@@ -1,5 +1,4 @@
 #!/usr/bin/make -f
-export DH_OPTIONS
 export DH_VERBOSE = 1
 export DH_GOPKG:=github.com/clearcontainers/runtime
 export DEB_BUILD_OPTIONS=nocheck

--- a/runtime/update_runtime.sh
+++ b/runtime/update_runtime.sh
@@ -29,8 +29,6 @@ else
 fi
 
 
-GO_VERSION=${GO_VERSION:-"1.8.3"}
-
 echo "Running: $0 $@"
 echo "Update cc-runtime $VERSION: ${hash_tag:0:7}"
 
@@ -51,7 +49,6 @@ changelog_update $VERSION
 
 function templating_non_staging(){
     sed -e "s/@VERSION@/$VERSION/" \
-        -e "s/@GO_VERSION@/$GO_VERSION/g;" \
         -e "s/@cc_proxy_version@/$proxy_obs_fedora_version/" \
         -e "s/@cc_shim_version@/$shim_obs_fedora_version/" \
         -e "s/@cc_image_version@/$image_obs_fedora_version/" \
@@ -80,8 +77,7 @@ function templating_non_staging(){
 
 function templating_staging(){
 
-    sed -e "s/@VERSION@/$VERSION/" \
-        -e "s/@GO_VERSION@/$GO_VERSION/g;" cc-runtime.spec-template > cc-runtime.spec
+    sed -e "s/@VERSION@/$VERSION/" cc-runtime.spec-template > cc-runtime.spec
 
     sed -e "s/@VERSION_DEB_TRANSFORM@/$VERSION_DEB_TRANSFORM/g;" \
         -e "s/@HASH_TAG@/$short_hashtag/g;" cc-runtime.dsc-template > cc-runtime.dsc
@@ -132,9 +128,8 @@ then
     [ -f debian.series ] && cp debian.series $TMPDIR || :
     cd $TMPDIR
 
-    if [ ! -e "go${GO_VERSION}.linux-amd64.tar.gz" ]; then
+    if [ -e "go1.8.3.linux-amd64.tar.gz" ]; then
         rm go*.tar.gz
-        curl -OkL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz
     fi
     osc $APIURL addremove
     osc $APIURL commit -m "Update cc-runtime $VERSION: ${hash_tag:0:7}"

--- a/shim/update_shim.sh
+++ b/shim/update_shim.sh
@@ -27,8 +27,6 @@ else
     APIURL=""
 fi
 
-GO_VERSION=${GO_VERSION:-"1.8.3"}
-
 echo "Running: $0 $@"
 echo "Update cc-shim $VERSION: ${hash_tag:0:7}"
 


### PR DESCRIPTION
This commit will use a feature of OBS to download automatically go
tarball. It will improve mantainability speed and source size.

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>