### PR TITLE
obs: Update default path of cc-kernel and cc-image

### DIFF
--- a/clear-containers-image/update_image.sh
+++ b/clear-containers-image/update_image.sh
@@ -14,7 +14,7 @@ source "$CC_VERSIONS_FILE"
 VERSION=${1:-$clear_vm_image_version}
 
 OBS_PUSH=${OBS_PUSH:-false}
-OBS_CC_IMAGE_REPO=${OBS_CC_IMAGE_REPO:-home:clearlinux:preview:clear-containers-staging/clear-containers-image}
+OBS_CC_IMAGE_REPO=${OBS_CC_IMAGE_REPO:-home:clearcontainers:clear-containers-3-staging/clear-containers-image}
 
 git checkout obs_working_directory/debian/changelog
 last_release=`cat obs_working_directory/debian/changelog | head -1 | awk '{print $2}' | cut -d'-' -f2 | tr -d ')'`

--- a/kernel/update_kernel.sh
+++ b/kernel/update_kernel.sh
@@ -12,7 +12,7 @@ AUTHOR=${AUTHOR:-$(git config user.name)}
 AUTHOR_EMAIL=${AUTHOR_EMAIL:-$(git config user.email)}
 
 OBS_PUSH=${OBS_PUSH:-false}
-OBS_CC_KERNEL_REPO=${OBS_CC_KERNEL_REPO:-home:clearlinux:preview:clear-containers-staging/linux-container}
+OBS_CC_KERNEL_REPO=${OBS_CC_KERNEL_REPO:-home:clearcontainers:clear-containers-3-staging/linux-container}
 
 VERSION=${1:-latest}
 


### PR DESCRIPTION
This commit updates the default target to upload linux-container kernel
and clear-containers-image to the staging area of 3.0.

Clear Containers 2.1 and 3.0 were sharing the same image and linux
kernel, however 2.1 has been moved to maintenance mode. And we do not
want to affect the versions that were released in 2.1.

Fixes #78

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>