### PR TITLE
kernel: Fix release number

### DIFF
--- a/kernel/linux-container.dsc-template
+++ b/kernel/linux-container.dsc-template
@@ -1,6 +1,6 @@
 Format: 3.0 (quilt)
 Source: linux-container
-Version: @VERSION@
+Version: @VERSION@-@RELEASE@
 Section: devel
 Priority: optional
 Maintainer: clear containers team <cc-devel@lists.01.org>
@@ -8,7 +8,6 @@ Build-Depends: debhelper (>= 9), cpio, libelf-dev, libnewt-dev, libiberty-dev, r
 Standards-Version: 3.9.6
 Homepage: https://clearlinux.org/features/clear-containers
 Debtransform-Tar: linux-@VERSION@.tar.xz
-DEBTRANSFORM-RELEASE: 1
 
 Package: linux-container
 Architecture: amd64

--- a/kernel/linux-container.spec-template
+++ b/kernel/linux-container.spec-template
@@ -6,7 +6,7 @@
 
 Name:           linux-container
 Version:        @VERSION@
-Release:        @RELEASE@
+Release:        @RELEASE@.<B_CNT>
 License:        GPL-2.0
 Summary:        The Linux kernel optimized for running inside a container
 Url:            http://www.kernel.org/

--- a/kernel/update_kernel.sh
+++ b/kernel/update_kernel.sh
@@ -49,7 +49,7 @@ echo "Update linux-container to: $VERSION-$next_release"
 changelog_update ${VERSION}
 
 sed "s/\@VERSION\@/${VERSION}/g; s/\@RELEASE\@/${next_release}/g" linux-container.spec-template > linux-container.spec
-sed "s/\@VERSION\@/${VERSION}/g" linux-container.dsc-template > linux-container.dsc
+sed "s/\@VERSION\@/${VERSION}/g; s/\@RELEASE\@/${next_release}/g" linux-container.dsc-template > linux-container.dsc
 sed "s/\@VERSION\@/${VERSION}/g; s/\@KERNEL_SHA256\@/${kernel_sha256}/g" _service-template > _service
 
 if [ $? = 0 ] && [ "$OBS_PUSH" = true ]


### PR DESCRIPTION
This commit will force the RELEASE number to stay the same across
multiple builds in different distros

Fixes: #84

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>