### PR TITLE
kernel: Fix duplicate kernel version in ubuntu

### DIFF
--- a/kernel/debian.rules
+++ b/kernel/debian.rules
@@ -6,7 +6,7 @@ KernelVer=${DEB_VERSION_UPSTREAM_REVISION}.container
 	dh $@
 
 override_dh_auto_build:
-	perl -p -i -e "s/^EXTRAVERSION.*/EXTRAVERSION = -${KernelVer}/" Makefile
+	sed -i "s/^EXTRAVERSION.*/EXTRAVERSION = -$$(echo $(KernelVer) | cut -d'-' -f2)/" Makefile
 	cp /usr/src/packages/SOURCES/config .config
 	make -s ARCH=x86_64 oldconfig > /dev/null
 	make -s CONFIG_DEBUG_SECTION_MISMATCH=y -j8 ARCH=x86_64 all


### PR DESCRIPTION
This commit fixes the duplicate kernel version in ubuntu builds.

Fixes: #87

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>