### PR TITLE
runtime: Do conflict with cc-oci-runtime

### DIFF
--- a/runtime/cc-runtime.dsc-template
+++ b/runtime/cc-runtime.dsc-template
@@ -15,19 +15,22 @@ Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime-bin, cc-runtime-config, qemu-lite (>= @qemu_lite_version@),
                           clear-containers-image (>= @cc_image_version@), linux-container (>= @linux_container_version@),
 			  cc-proxy (>= @cc_proxy_version@), cc-shim (>= @cc_shim_version@)
+Provides: cc-oci-runtime
+Conflicts: cc-oci-runtime
+Replaces: cc-oci-runtime
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
 
 Package: cc-runtime-bin
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
  This package contain the cc-runtime and the pause binaries.
 
 Package: cc-runtime-config
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
  This package contain the configuration file.

--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -26,6 +26,15 @@ Requires: linux-container >= @linux_container_version@
 Requires: cc-proxy >= @cc_proxy_version@
 Requires: cc-shim >= @cc_shim_version@
 
+Conflicts: cc-oci-runtime
+Conflicts: cc-oci-runtime-bin
+Conflicts: cc-oci-runtime-config
+Conflicts: cc-oci-runtime-data
+Obsoletes: cc-oci-runtime
+Obsoletes: cc-oci-runtime-bin
+Obsoletes: cc-oci-runtime-config
+Obsoletes: cc-oci-runtime-data
+
 %description
 .. contents::
 .. sectnum::

--- a/runtime/debian.control-template
+++ b/runtime/debian.control-template
@@ -13,19 +13,22 @@ Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime-bin, cc-runtime-config, qemu-lite (>= @qemu_lite_version@),
                             clear-containers-image (>= @cc_image_version@), linux-container (>= @linux_container_version@),
 			    cc-proxy (>= @cc_proxy_version@), cc-shim (>= @cc_shim_version@)
+Provides: cc-oci-runtime
+Conflicts: cc-oci-runtime
+Replaces: cc-oci-runtime
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
 
 Package: cc-runtime-bin
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
  This package contain the cc-runtime and the pause binaries.
 
 Package: cc-runtime-config
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Clear Containers 3.0 hypervisor, rather than a standard Linux container.
  This package contain the configuration file.


### PR DESCRIPTION
This commit enables cc-runtime, when install the package, to conflict
with a previous version (2.X). The installer will attempt to uninstall this
previous (and conflicting) version and proceed to install cc-runtime.
This fix enables the upgrade path from 2.X to 3.X

Fixes #93
