### PR TITLE
cc-shim: Apply patch to make OpenSuSE Tumbleweed build

### DIFF
--- a/shim/69.patch
+++ b/shim/69.patch
@@ -1,0 +1,30 @@
+From fab4438e835a0a6f7f5db9493884510e70c31637 Mon Sep 17 00:00:00 2001
+From: Archana Shinde <archana.m.shinde@intel.com>
+Date: Fri, 8 Sep 2017 17:06:18 -0700
+Subject: [PATCH] signal: Conditionally use depecrated signal constant
+ SIGUNUSED
+
+With glibc 2.6, the obsolete signal constant SIGUNUSED is no longer
+defined by signal.h. Use #ifdef to use it if present.
+
+Fixes #68
+
+Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
+---
+ src/utils.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/utils.c b/src/utils.c
+index ee13132..b88628c 100644
+--- a/src/utils.c
++++ b/src/utils.c
+@@ -64,7 +64,9 @@ int shim_signal_table[] = {
+ 	SIGIO,               /* I/O now possible */
+ 	SIGPWR,              /* Power failure restart */
+ 	//SIGSYS,            /* Bad system call */
++#ifdef SIGUNUSED
+ 	SIGUNUSED,
++#endif
+ 	0,
+ };
+ 

--- a/shim/cc-shim.spec-template
+++ b/shim/cc-shim.spec-template
@@ -8,15 +8,18 @@
 Name:      cc-shim
 Version:   @VERSION@
 Release:   0
+Summary  : No detailed summary available
+Group    : Development/Tools
+License  : Apache-2.0
 Source0:   %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: autoconf
 BuildRequires: automake
-Summary  : No detailed summary available
-Group    : Development/Tools
-License  : Apache-2.0
-
 Requires: cc-shim-bin
+
+%if 0%{?is_opensuse}
+Patch69: 69.patch
+%endif
 
 %description
 .. contents::
@@ -35,6 +38,10 @@ bin components for the cc-oci-shim package.
 
 %prep
 %setup -q
+
+%if 0%{?is_opensuse}
+%patch69 -p1
+%endif
 
 %build
 ./autogen.sh --libexecdir=%{LIBEXECDIR}/clear-containers

--- a/shim/debian.changelog
+++ b/shim/debian.changelog
@@ -2,6 +2,12 @@ cc-shim (3.0.0-beta.2) stable; urgency=medium
 
   * Update cc-shim 3.0.0-beta.2 1f545df
 
+ -- Geronimo Orozco <geronimo.orozco@intel.com>  Sat, 09 Sep 2017 21:03:48 -0500
+
+cc-shim (3.0.0-beta.2) stable; urgency=medium
+
+  * Update cc-shim 3.0.0-beta.2 1f545df
+
  -- Geronimo Orozco <geronimo.orozco@intel.com>  Sun, 03 Sep 2017 15:58:38 -0500
 
 cc-shim (3.0.0-alpha.4) stable; urgency=medium


### PR DESCRIPTION
Apply patch https://github.com/clearcontainers/shim/issues/65
to fix `cc-shim` not building in OpenSuSE tumbleweed.

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>