### PR TITLE
runtime: ship bash-completion script

### DIFF
--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -88,7 +88,7 @@ export GOPATH=$HOME/rpmbuild/BUILD/go/
 
 cd $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 make install DESTDIR=%{buildroot} PREFIX=/usr SYSCONFDIR=/etc LOCALSTATEDIR=/var SHAREDIR=/usr/share \
-     VERSION=@VERSION@ COMMIT=@HASH@
+     VERSION=@VERSION@ COMMIT=@HASH@ BASH_COMPLETIONSDIR=%{buildroot}/usr/share/bash-completion/completions/cc-runtime
 
 %files
 %defattr(-,root,root,-)
@@ -102,6 +102,9 @@ make install DESTDIR=%{buildroot} PREFIX=/usr SYSCONFDIR=/etc LOCALSTATEDIR=/var
 /var/lib/clear-containers/runtime/bundles/pause_bundle
 /var/lib/clear-containers/runtime/bundles/pause_bundle/bin
 /var/lib/clear-containers/runtime/bundles/pause_bundle/bin/pause
+/usr/share/bash-completion
+/usr/share/bash-completion/completions
+/usr/share/bash-completion/completions/cc-runtime
 
 %files config
 %defattr(-,root,root,-)

--- a/runtime/debian.rules-template
+++ b/runtime/debian.rules-template
@@ -22,5 +22,5 @@ override_dh_auto_build:
 override_dh_auto_install:
 	mkdir -p debian/cc-runtime
 	cd $(GOPATH)/src/github.com/clearcontainers/runtime/; \
-	make install DESTDIR=`pwd`/debian/cc-runtime PREFIX=/usr SYSCONFDIR=/etc LOCALSTATEDIR=/var \
-        SHAREDIR=/usr/share VERSION=@VERSION@ COMMIT=@HASH@
+	make install DESTDIR=$(shell pwd)/debian/cc-runtime PREFIX=/usr SYSCONFDIR=/etc LOCALSTATEDIR=/var \
+        SHAREDIR=/usr/share VERSION=@VERSION@ COMMIT=@HASH@ BASH_COMPLETIONSDIR=$(shell pwd)/debian/cc-runtime/usr/share/bash-completion/completions/cc-runtime


### PR DESCRIPTION
This commit adds the bash-completion script to the spec/dsc files. New
packages will now ship the bash completion script.

Fixes #109

Output sample:
Ubuntu Xenial
```
ubuntu@cc-ubuntu:~$ cc-runtime
cc-check  cc-env create    delete    exec      h         help      kill      list      pause     resume    run       start     state     version
ubuntu@cc-ubuntu:~$ cc-runtime cc-
cc-check  cc-env
```
Fedora 25
```
[fedora@cc-fedora ~]$ cc-runtime
cc-check  cc-env    create    delete    exec      h         help      kill      list      pause     resume    run       start     state     version
[fedora@cc-fedora ~]$ cc-runtime cc-
cc-check  cc-env

```
