### PR TITLE
opensuse: Fix OpenSuSE requirement to build cc-runtime properly

### DIFF
--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -18,6 +18,9 @@ Group    : Development/Tools
 License  : Apache-2.0
 
 BuildRequires: git
+%if 0%{?suse_version} && 0%{?is_opensuse}
+BuildRequires: openSUSE-release
+%endif
 Requires: cc-runtime-bin
 Requires: cc-runtime-config
 %{!?el7:Requires: qemu-lite }


### PR DESCRIPTION
cc-runtime has a requeriment to detect distro in the Makefile looking
for /etc/os-release or /usr/lib/os-releases

/etc/os-release is shipped by openSUSE-release package in tumbleweed
and Leap 42.x

Fixes: #115

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>