### PR TITLE
packages: Fix build from branch/commit ID

### DIFF
--- a/proxy/_service-template
+++ b/proxy/_service-template
@@ -4,7 +4,7 @@
     <param name="url">https://github.com/clearcontainers/proxy.git</param>
     <param name="filename">cc-proxy</param>
     <param name="versionformat">@PARENT_TAG@+git.%h</param>
-    <param name="revision">@VERSION@</param>
+    <param name="revision">@REVISION@</param>
  </service>
  <service name="recompress">
     <param name="file">*.tar*</param>

--- a/proxy/update_proxy.sh
+++ b/proxy/update_proxy.sh
@@ -10,20 +10,27 @@ AUTHOR=${AUTHOR:-$(git config user.name)}
 AUTHOR_EMAIL=${AUTHOR_EMAIL:-$(git config user.email)}
 
 source ../versions.txt
-VERSION=${1:-$cc_proxy_version}
+VERSION=$cc_proxy_version
 
-# If we are providing the branch or hash to build we'll take version as the hashtag
-[ -n "$1" ] && hash_tag=$VERSION || hash_tag=$cc_proxy_hash
-short_hashtag="${hash_tag:0:7}"
+# If we are providing the branch or hash to build, assign it to OBS_REVISION
+if [ -n "$1" ]; then
+     OBS_REVISION=$1
 
-if [[ ${VERSION::1} =~ [a-z] ]]; then
-    ORIGINAL_VERSION=$VERSION
-    VERSION=1${VERSION:1}
+     # Validate input is alphanumeric, commit ID
+     # If a commit ID is provided, override versions.txt one
+     if [[ "$OBS_REVISION" =~ ^[a-zA-Z0-9][-a-zA-Z0-9]{0,40}[a-zA-Z0-9]$  ]]; then
+         hash_tag=$OBS_REVISION
+     else
+         hash_tag=$cc_proxy_hash
+     fi
+else
+         hash_tag=$cc_proxy_hash
 fi
+short_hashtag="${hash_tag:0:7}"
 
 OBS_PUSH=${OBS_PUSH:-false}
 OBS_PROXY_REPO=${OBS_PROXY_REPO:-home:clearcontainers:clear-containers-3-staging/cc-proxy}
-: ${OBS_APIURL:=""}
+OBS_APIURL=${OBS_APIURL:-""}
 
 # This allows to point to internal/private OBS instance
 if [ "$OBS_APIURL" != "" ]; then
@@ -66,13 +73,15 @@ sed -e "s/@VERSION@/$VERSION/g" \
 
 sed -e "s/@VERSION@/$VERSION/g" debian.control-template > debian.control
 
-if [ -z "$ORIGINAL_VERSION" ]; then
-    sed "s/@VERSION@/$VERSION/g;" _service-template > _service
+# If OBS_REVISION is not empty, which means a branch or commit ID has been passed as argument,
+# replace It as @REVISION@ it in the OBS _service file. Otherwise, use the VERSION variable,
+# which uses the version from versions.txt.
+# This will determine which source tarball will be retrieved from github.com
+if [ -n "$OBS_REVISION" ]; then
+    sed "s/@REVISION@/$OBS_REVISION/" _service-template > _service
 else
-    sed "s/@VERSION@/$ORIGINAL_VERSION/g;" _service-template > _service
+    sed "s/@REVISION@/$VERSION/"  _service-template > _service
 fi
-
-[ -n "$1" ] && sed -e "s/@PARENT_TAG@/$VERSION/" -i _service || :
 
 # Update and package OBS
 if [ "$OBS_PUSH" = true ]

--- a/runtime/_service-template
+++ b/runtime/_service-template
@@ -5,7 +5,7 @@
     <param name="exclude">.git</param>
     <param name="filename">cc-runtime</param>
     <param name="versionformat">@PARENT_TAG@+git.%h</param>
-    <param name="revision">@VERSION@</param>
+    <param name="revision">@REVISION@</param>
  </service>
  <service name="recompress">
     <param name="file">*.tar*</param>

--- a/runtime/update_runtime.sh
+++ b/runtime/update_runtime.sh
@@ -10,16 +10,23 @@ AUTHOR=${AUTHOR:-$(git config user.name)}
 AUTHOR_EMAIL=${AUTHOR_EMAIL:-$(git config user.email)}
 
 source ../versions.txt
-VERSION=${1:-$cc_runtime_version}
+VERSION=$cc_runtime_version
 
-# If we are providing the branch or hash to build we'll take version as the hashtag
-[ -n "$1" ] && hash_tag=$VERSION || hash_tag=$cc_runtime_hash
-short_hashtag="${hash_tag:0:7}"
+# If we are providing the branch or hash to build, assign it to OBS_REVISION
+if [ -n "$1" ]; then
+     OBS_REVISION=$1
 
-if [[ ${VERSION::1} =~ [a-z] ]]; then
-    ORIGINAL_VERSION=$VERSION
-    VERSION=1${VERSION:1}
+     # Validate input is alphanumeric, commit ID
+     # If a commit ID is provided, override versions.txt one
+     if [[ "$OBS_REVISION" =~ ^[a-zA-Z0-9][-a-zA-Z0-9]{0,40}[a-zA-Z0-9]$  ]]; then
+         hash_tag=$OBS_REVISION
+     else
+         hash_tag=$cc_runtime_hash
+     fi
+else
+         hash_tag=$cc_runtime_hash
 fi
+short_hashtag="${hash_tag:0:7}"
 
 OBS_PUSH=${OBS_PUSH:-false}
 OBS_RUNTIME_REPO=${OBS_RUNTIME_REPO:-home:clearcontainers:clear-containers-3-staging/cc-runtime}
@@ -84,13 +91,15 @@ sed -e "s/@VERSION@/$VERSION/" \
     -e "s/@linux_container_version@/$linux_container_obs_ubuntu_version/" \
     -e "s/@qemu_lite_obs_ubuntu_version@/$qemu_lite_obs_ubuntu_version/"  debian.control-template > debian.control
 
-if [ -z "$ORIGINAL_VERSION" ]; then
-    sed "s/@VERSION@/$VERSION/g;" _service-template > _service
+# If OBS_REVISION is not empty, which means a branch or commit ID has been passed as argument,
+# replace It as @REVISION@ it in the OBS _service file. Otherwise, use the VERSION variable,
+# which uses the version from versions.txt.
+# This will determine which source tarball will be retrieved from github.com
+if [ -n "$OBS_REVISION" ]; then
+    sed "s/@REVISION@/$OBS_REVISION/" _service-template > _service
 else
-    sed "s/@VERSION@/$ORIGINAL_VERSION/g;" _service-template > _service
+    sed "s/@REVISION@/$VERSION/"  _service-template > _service
 fi
-
-[ -n "$1" ] && sed -e "s/@PARENT_TAG@/$VERSION/" -i _service || :
 
 # Update and package OBS
 if [ "$OBS_PUSH" = true ]

--- a/shim/_service-template
+++ b/shim/_service-template
@@ -4,7 +4,7 @@
     <param name="url">https://github.com/clearcontainers/shim.git</param>
     <param name="filename">cc-shim</param>
     <param name="versionformat">@PARENT_TAG@+git.%h</param>
-    <param name="revision">@VERSION@</param>
+    <param name="revision">@REVISION@</param>
  </service>
  <service name="recompress">
     <param name="file">*.tar*</param>


### PR DESCRIPTION
This commit fixes the behaviour when building from a commit ID.
It now correctly replaces version strings and commit IDs.

Fixes #124

