### PR TITLE
automation: Fix kernel automation with same string in version

### DIFF
--- a/kernel/update_kernel.sh
+++ b/kernel/update_kernel.sh
@@ -40,7 +40,7 @@ echo ${next_release} > release
 
 if [ "${VERSION}" = "latest" ]
 then
-    VERSION=$(curl -L -s -f ${KR_REL} | grep "${KR_LTS}" | grep version | cut -f 4 -d \")
+    VERSION=$(curl -L -s -f ${KR_REL} | grep "${KR_LTS}" | grep version | cut -f 4 -d \" | grep "^${KR_LTS}")
 fi
 
 kernel_sha256=$(curl -L -s -f ${KR_SHA} | awk '/linux-'${VERSION}'.tar.xz/ {print $1}')


### PR DESCRIPTION
This fixes the search for the proper kernel lts in the automation
tooling.

Fixes: #145

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>