### PR TITLE
packages: Apport hook

### DIFF
--- a/proxy/debian.rules-template
+++ b/proxy/debian.rules-template
@@ -17,4 +17,6 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir debian/cc-proxy
+	install -D /usr/src/packages/SOURCES/source_cc-proxy.py \
+	debian/cc-proxy/usr/share/apport/package-hooks/source_cc-proxy.py
 	make install DESTDIR=`pwd`/debian/cc-proxy UNIT_DIR=/usr/lib/systemd/system VERSION=@VERSION_STRING@

--- a/proxy/update_proxy.sh
+++ b/proxy/update_proxy.sh
@@ -102,6 +102,9 @@ then
         debian.compat \
         *.patch \
         $TMPDIR
+
+    cp ../scripts/apport_hook.py $TMPDIR/source_cc-proxy.py
+
     [ -f debian.series ] && cp debian.series $TMPDIR || :
     cd $TMPDIR
 

--- a/qemu-lite/debian.rules-template
+++ b/qemu-lite/debian.rules-template
@@ -67,6 +67,9 @@ override_dh_auto_install:
 		mv $$file "$$dir"/"$$new" ; \
 	done
 
+	install -D /usr/src/packages/SOURCES/source_qemu-lite.py \
+	debian/qemu-lite/usr/share/apport/package-hooks/source_qemu-lite.py
+
 override_dh_auto_test:
 	echo "Skip dh_auto_test"
 

--- a/qemu-lite/update_qemu.sh
+++ b/qemu-lite/update_qemu.sh
@@ -64,6 +64,9 @@ then
         _service \
         *.patch \
         $TMPDIR
+
+    cp ../scripts/apport_hook.py $TMPDIR/source_qemu-lite.py
+
     [ -f debian.series ] && cp debian.series $TMPDIR || :
     cd $TMPDIR
     osc addremove

--- a/runtime/debian.rules-template
+++ b/runtime/debian.rules-template
@@ -25,6 +25,10 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir -p debian/cc-runtime
+
+	install -D /usr/src/packages/SOURCES/source_cc-runtime.py \
+	debian/cc-runtime/usr/share/apport/package-hooks/source_cc-runtime.py
+
 	cd $(GOPATH)/src/github.com/clearcontainers/runtime/; \
 	make install \
 		DESTDIR=$(shell pwd)/debian/cc-runtime \

--- a/runtime/update_runtime.sh
+++ b/runtime/update_runtime.sh
@@ -122,6 +122,9 @@ then
         cc-runtime-config.install \
         *.patch \
         $TMPDIR
+
+    cp ../scripts/apport_hook.py $TMPDIR/source_cc-runtime.py
+
     [ -f debian.series ] && cp debian.series $TMPDIR || :
     cd $TMPDIR
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,3 +15,10 @@ Example usage:
 ```
   $ configure-hypervisor.sh qemu-lite
 ```
+
+## `apport_hook.py`
+
+This script is a basic hook which will call the cc-collect-data.sh script
+when any of the components crashes (runtime, proxy, shim, qemu-lite).
+The script output will then be added to the standard Ubuntu bug report
+that will get created on launchpad.net.

--- a/scripts/apport_hook.py
+++ b/scripts/apport_hook.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Apport hook for Intel® Clear Containers
+"""
+
+import apport.hookutils
+
+def add_info(report, ui):
+    report['cc-collect-data'] = apport.hookutils.command_output(['cc-collect-data.sh'])

--- a/shim/debian.rules-template
+++ b/shim/debian.rules-template
@@ -9,4 +9,6 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir -p debian/cc-shim
+	install -D /usr/src/packages/SOURCES/source_cc-shim.py \
+	debian/cc-shim/usr/share/apport/package-hooks/source_cc-shim.py
 	make install DESTDIR=`pwd`/debian/cc-shim

--- a/shim/update_shim.sh
+++ b/shim/update_shim.sh
@@ -103,6 +103,9 @@ then
         debian.compat \
         *.patch \
         $TMPDIR
+
+    cp ../scripts/apport_hook.py $TMPDIR/source_cc-shim.py
+    
     [ -f debian.series ] && cp debian.series $TMPDIR || :
     cd $TMPDIR
     osc $APIURL addremove


### PR DESCRIPTION
This set of commits adds the Apport hook for Ubuntu packages.

Fixes #135

Note: Added separate commits for better review. Can be squashed once reviewed.