### PR TITLE
mantainers: Update mantainers to clear containers team

### DIFF
--- a/clear-containers-image/debian.control
+++ b/clear-containers-image/debian.control
@@ -1,7 +1,7 @@
 Source: clear-containers-image
 Section: devel
 Priority: optional
-Maintainer: clearlinux.org team <dev@lists.clearlinux.org>
+Maintainer: clear containers team <cc-devel@lists.01.org>
 Build-Depends: debhelper (>= 9), flex, bison
 Standards-Version: 3.9.6
 Homepage: https://clearlinux.org/features/clear-containers

--- a/proxy/cc-proxy.dsc-template
+++ b/proxy/cc-proxy.dsc-template
@@ -3,7 +3,7 @@ Source: cc-proxy
 Version: @VERSION@+git.@HASH@-@RELEASE@
 Section: devel
 Priority: optional
-Maintainer: clearlinux.org team <dev@lists.clearlinux.org>
+Maintainer: clear containers team <cc-devel@lists.01.org>
 Standards-Version: 3.9.6
 Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases
 Homepage: https://clearlinux.org/features/clear-containers

--- a/proxy/debian.control-template
+++ b/proxy/debian.control-template
@@ -1,7 +1,7 @@
 Source: cc-proxy
 Section: devel
 Priority: optional
-Maintainer: clearlinux.org team <dev@lists.clearlinux.org>
+Maintainer: clear containers team <cc-devel@lists.01.org>
 Standards-Version: 3.9.6
 Homepage: https://clearlinux.org/features/clear-containers
 Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases

--- a/qemu-lite/debian.control
+++ b/qemu-lite/debian.control
@@ -1,7 +1,7 @@
 Source: qemu-lite
 Section: devel
 Priority: optional
-Maintainer: clearlinux.org team <dev@lists.clearlinux.org>
+Maintainer: clear containers team <cc-devel@lists.01.org>
 Build-Depends: debhelper (>= 9), cpio, libelf-dev, rsync, libdw-dev, pkg-config, flex, bison, libaudit-dev, bc, python-dev, gawk, autoconf, automake, libtool, libltdl-dev, libglib2.0-dev, libglib2.0-0, libcap-dev, libcap-ng-dev, libattr1-dev, m4, libnuma-dev, zlib1g-dev, libpixman-1-0, libpixman-1-dev
 Standards-Version: 3.9.6
 Homepage: https://clearlinux.org/features/clear-containers

--- a/qemu-lite/qemu-lite.dsc-template
+++ b/qemu-lite/qemu-lite.dsc-template
@@ -3,7 +3,7 @@ Source: qemu-lite
 Version: @VERSION@+git.@QEMU_LITE_HASH@-@RELEASE@
 Section: devel
 Priority: optional
-Maintainer: clearlinux.org team <dev@lists.clearlinux.org>
+Maintainer: clear containers team <cc-devel@lists.01.org>
 Build-Depends: debhelper (>= 9), cpio, libelf-dev, rsync, libdw-dev, pkg-config, flex, bison, libaudit-dev, bc, python-dev, gawk, autoconf, automake, libtool, libltdl-dev, libglib2.0-dev, libglib2.0-0, libcap-dev, libcap-ng-dev, libattr1-dev, m4, libnuma-dev, zlib1g-dev, libpixman-1-0, libpixman-1-dev
 Standards-Version: 3.9.6
 Homepage: https://clearlinux.org/features/clear-containers

--- a/runtime/cc-runtime.dsc-template
+++ b/runtime/cc-runtime.dsc-template
@@ -3,7 +3,7 @@ Source: cc-runtime
 Version: @VERSION@+git.@HASH@-@RELEASE@
 Section: devel
 Priority: optional
-Maintainer: clearlinux.org team <dev@lists.clearlinux.org>
+Maintainer: clear containers team <cc-devel@lists.01.org>
 Standards-Version: 3.9.6
 Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases
 Homepage: https://clearlinux.org/features/clear-containers

--- a/runtime/debian.control-template
+++ b/runtime/debian.control-template
@@ -1,7 +1,7 @@
 Source: cc-runtime
 Section: devel
 Priority: optional
-Maintainer: clearlinux.org team <dev@lists.clearlinux.org>
+Maintainer: clear containers team <cc-devel@lists.01.org>
 Standards-Version: 3.9.6
 Homepage: https://clearlinux.org/features/clear-containers
 Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases

--- a/shim/cc-shim.dsc-template
+++ b/shim/cc-shim.dsc-template
@@ -3,7 +3,7 @@ Source: cc-shim
 Version: @VERSION@+git.@HASH@-@RELEASE@
 Section: devel
 Priority: optional
-Maintainer: clearlinux.org team <dev@lists.clearlinux.org>
+Maintainer: clear containers team <cc-devel@lists.01.org>
 Standards-Version: 3.9.6
 Build-Depends: debhelper (>= 9), git, ca-certificates, dh-modaliases, execstack, devscripts, dh-make
 Homepage: https://clearlinux.org/features/clear-containers

--- a/shim/debian.control-template
+++ b/shim/debian.control-template
@@ -1,7 +1,7 @@
 Source: cc-shim
 Section: devel
 Priority: optional
-Maintainer: clearlinux.org team <dev@lists.clearlinux.org>
+Maintainer: clear containers team <cc-devel@lists.01.org>
 Standards-Version: 3.9.6
 Homepage: https://clearlinux.org/features/clear-containers
 Build-Depends: debhelper (>= 9), git, ca-certificates, dh-modaliases, execstack, devscripts, dh-make


### PR DESCRIPTION
Maintainers field must be changed to point to clear containers team and
its mailing list.

Fixes: #140

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>