### PR TITLE
image: Fix debian changelog format

### DIFF
--- a/clear-containers-image/update_image.sh
+++ b/clear-containers-image/update_image.sh
@@ -33,7 +33,7 @@ next_release=$(( $last_release + 1 ))
 
 echo "Running: $0 $@"
 echo "Update clear-containers-image to: $VERSION-$next_release"
-image_changes=$(${script_dir}/../scripts/get-image-changes.sh $VERSION)
+image_changes=$(${script_dir}/../scripts/get-image-changes.sh $VERSION | awk '{if (/^version/) print "  * "$0; else print "  "$0"\n"}')
 
 sed -i s/"clear_vm_image_version=${clear_vm_image_version}"/"clear_vm_image_version=${VERSION}"/ ${script_dir}/../versions.txt
 


### PR DESCRIPTION
This commit fix the update_image.sh script to correctly format
the debian.changelog file.

Fixes #159

Output sample:
```
clear-containers-image (18440-36) stable; urgency=medium

  * Update clear-containers-image from 18220 to 18440.

  * version: 18280
  Changes in package iptables (from 1.6.1-20 to 1.6.1-21):

       George T Kramer - iptables: Autospec creation for version 1.6.1

  https://download.clearlinux.org/releases/18280/clear/RELEASENOTES

  * version: 18400
  Changes in package clear-containers-agent (from 84761a194a72018c67f1fa8a6a1267b8ea120f82-12 to 2c127987830773e8d7cf6c8c5571b8ebd5e28171-13):

       Jose Carlos Venegas Munoz - version bump from 2c127987830773e8d7cf6c8c5571b8ebd5e28171-12 to 2c127987830773e8d7cf6c8c5571b8ebd5e28171-13

       Jose Carlos Venegas Munoz - new agent version 2c12798

  https://download.clearlinux.org/releases/18400/clear/RELEASENOTES

 -- Erick Cardona <erick.cardona.ruiz@intel.com>  Tue, 17 Oct 2017 11:29:12 -0500
```