### PR TITLE
runtime: update config file location

### DIFF
--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -77,7 +77,7 @@ mkdir -p $HOME/rpmbuild/BUILD/go/src/%{DOMAIN}/%{ORG}
 ln -s $HOME/rpmbuild/BUILD/cc-runtime-%{version} $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 cd $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 make PREFIX=/usr \
-   SYSCONFDIR=/etc \
+   SYSCONFDIR=/usr/share/defaults \
    LOCALSTATEDIR=/var \
    SHAREDIR=/usr/share \
    VERSION=@VERSION@ \
@@ -104,7 +104,10 @@ make install \
    COMMIT=@HASH@ \
    BASH_COMPLETIONSDIR=%{buildroot}/usr/share/bash-completion/completions/cc-runtime \
    DESTTARGET=%{buildroot}/usr/bin/cc-runtime \
-   DESTCONFIG=%{buildroot}/etc/clear-containers/configuration.toml 
+   DESTCONFIG=%{buildroot}/usr/share/defaults/clear-containers/configuration.toml
+
+%post
+[ -e /etc/clear-containers/configuration.toml ] && rm /etc/clear-containers/configuration.toml || :
 
 %files
 %defattr(-,root,root,-)
@@ -125,5 +128,6 @@ make install \
 
 %files config
 %defattr(-,root,root,-)
-/etc/clear-containers
-/etc/clear-containers/configuration.toml
+/usr/share/defaults/
+/usr/share/defaults/clear-containers/
+/usr/share/defaults/clear-containers/configuration.toml

--- a/runtime/debian.postinst
+++ b/runtime/debian.postinst
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+[ -e /etc/clear-containers/configuration.toml ] && rm /etc/clear-containers/configuration.toml || :

--- a/runtime/debian.rules-template
+++ b/runtime/debian.rules-template
@@ -17,7 +17,7 @@ override_dh_auto_build:
 	ln -s /usr/src/packages/BUILD /usr/src/packages/BUILD/go/src/github.com/clearcontainers/runtime
 	cd $(GOPATH)/src/github.com/clearcontainers/runtime/; \
 	make PREFIX=/usr \
-		SYSCONFDIR=/etc \
+		SYSCONFDIR=/usr/share/defaults \
 		LOCALSTATEDIR=/var \
 		SHAREDIR=/usr/share \
 		VERSION=@VERSION@ \
@@ -40,5 +40,5 @@ override_dh_auto_install:
 		COMMIT=@HASH@ \
 		BASH_COMPLETIONSDIR=$(shell pwd)/debian/cc-runtime/usr/share/bash-completion/completions/cc-runtime \
 		DESTTARGET=$(shell pwd)/debian/cc-runtime/usr/bin/cc-runtime \
-		DESTCONFIG=$(shell pwd)/debian/cc-runtime/etc/clear-containers/configuration.toml 
+		DESTCONFIG=$(shell pwd)/debian/cc-runtime/usr/share/defaults/clear-containers/configuration.toml 
 

--- a/runtime/update_runtime.sh
+++ b/runtime/update_runtime.sh
@@ -121,6 +121,7 @@ then
         cc-runtime-bin.install \
         cc-runtime-config.install \
         *.patch \
+        debian.postinst \
         $TMPDIR
 
     cp ../scripts/apport_hook.py $TMPDIR/source_cc-runtime.py


### PR DESCRIPTION
This commit updates the new config file location and removes the old
one using post-install routines.

Fixes #161

