### PR TITLE
kernel: Add kernel config for ACPI hotplug

### DIFF
--- a/kernel/kernel-config-4.9.x
+++ b/kernel/kernel-config-4.9.x
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.47 Kernel Configuration
+# Linux/x86 4.9.54 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y
@@ -604,7 +604,8 @@ CONFIG_PCI_MSI_IRQ_DOMAIN=y
 # CONFIG_PCI_PASID is not set
 CONFIG_PCI_LABEL=y
 CONFIG_HOTPLUG_PCI=y
-# CONFIG_HOTPLUG_PCI_ACPI is not set
+CONFIG_HOTPLUG_PCI_ACPI=y
+# CONFIG_HOTPLUG_PCI_ACPI_IBM is not set
 # CONFIG_HOTPLUG_PCI_CPCI is not set
 # CONFIG_HOTPLUG_PCI_SHPC is not set
 


### PR DESCRIPTION
This is needed for hotplugging devices based on
ACPI hotplug mechanism.

Fixes #168

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>