### PR TITLE
packages: Add Dockerfile and documentation for local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM opensuse:leap
+
+RUN zypper -n install osc-plugin-install vim curl bsdtar git sudo pcre-tools
+RUN curl -OkL https://download.opensuse.org/repositories/openSUSE:Tools/openSUSE_42.3/openSUSE:Tools.repo
+RUN zypper -n addrepo openSUSE:Tools.repo
+RUN zypper --gpg-auto-import-keys refresh
+RUN zypper -n install build \
+    obs-service-tar_scm \
+    obs-service-verify_file \
+    obs-service-obs_scm \
+    obs-service-recompress \
+    obs-service-download_url
+

--- a/README.rst
+++ b/README.rst
@@ -78,3 +78,49 @@ Repositories
 .. _`clear-containers-image`: https://download.clearlinux.org/current/
 
 .. _`clear-containers-selinux`: https://github.com/clearcontainers/proxy/tree/master/selinux
+
+Local Building
+==============
+
+Any user can build their own Clear Containers packages using the source files provided in this
+repository, either by using the OBS platform or their own machines using the ``osc`` (Open Build Service command line tool).
+
+In this repository, a Dockerfile is provided to build a container that has all the tools needed to perform local builds.
+Use the following instructions to build Clear Containers packages within the container:
+
+NOTES:
+
+When local building, a prompt will pop up asking for OBS credentials for the first time, the osc tool will contact
+the OBS API for retrieving the current OBS revision of a given package and the buildroot packages. If you don't
+have an account, you can create one from the main OBS site: https://build.opensuse.org/
+
+.. code-block:: shell
+
+   # cd into this repository
+   $ cd <this repo location>
+
+   # build the container image
+   # cc-osc name is used for the tag, it can be anything.
+   $ sudo docker build -t cc-osc .
+
+   # If you are behind a proxy, use instead the following paramenters to build the container.
+   $ sudo docker build --build-arg=http_proxy=http://<host>:<port> --build-arg=https_proxy=http://<host>:<port> -t cc-osc .
+
+   # Run the container and bind this repository.
+   # In order to make the packages visible from the host, we need to bind a host directory
+   # to the directory within the container where the packages are stored (/var/packaging/results).
+   # Change the results variable to change the default host directory.
+   $ results=/var/packaging/results
+   $ sudo mkdir -p "$results"
+   $ sudo docker run -v $PWD:/root/packaging -v /var/packaging/results:$results -it cc-osc bash
+
+   # Inside the container, cd to a project, runtime in this case
+   $ cd /root/packaging/runtime
+
+   # To see the options, arguments, etc
+   $ ./update_runtime.sh --help
+
+   # to build locally, run the setup script with the following parameters:
+   $ ./update_runtime.sh --local-build --verbose
+
+   # If something goes wrong, the build logs can be found in /var/packaging/build_logs within the container.


### PR DESCRIPTION
This commit adds a Dockerfile and proper documentation explaining how
to test changes with locally built packages using an openSUSE-based
container.

Fixes #156

Signed-off-by: Erick Cardona <erick.cardona.ruiz@intel.com>