### PR TITLE
runtime: fix LIBEXECDIR path for SUSE and openSUSE

### DIFF
--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -6,6 +6,12 @@
 %global IMPORTNAME %{DOMAIN}/%{ORG}/%{PROJECT}
 %global GO_VERSION 1.8.3
 
+%if 0%{?suse_version}
+%define LIBEXECDIR %{_libdir}
+%else
+%define LIBEXECDIR %{_libexecdir}
+%endif
+
 %undefine _missing_build_ids_terminate_build
 %define  debug_package %{nil}
 Name:      cc-runtime
@@ -77,6 +83,7 @@ mkdir -p $HOME/rpmbuild/BUILD/go/src/%{DOMAIN}/%{ORG}
 ln -s $HOME/rpmbuild/BUILD/cc-runtime-%{version} $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 cd $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 make PREFIX=/usr \
+   LIBEXECDIR=%{LIBEXECDIR} \
    SYSCONFDIR=/usr/share/defaults \
    LOCALSTATEDIR=/var \
    SHAREDIR=/usr/share \
@@ -95,6 +102,7 @@ export GOPATH=$HOME/rpmbuild/BUILD/go/
 
 cd $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 make install \
+   LIBEXECDIR=%{LIBEXECDIR} \
    DESTDIR=%{buildroot} \
    PREFIX=/usr \
    SYSCONFDIR=/etc \


### PR DESCRIPTION
SUSE/openSUSE's LIBEXECDIR points to /usr/lib64.
This commit adds a conditional to the specfile which handles
the LIBEXECDIR path when SUSE or openSUSE are used as build
targets. This will cause the configuration.toml points to the right
directory to look for cc-shim and cc-proxy binaries.

Fixes #192

Signed-off-by: Erick Cardona <erick.cardona.ruiz@intel.com>