### PR TITLE
go: Define a go version for building packages

### DIFF
--- a/proxy/_service-template
+++ b/proxy/_service-template
@@ -13,11 +13,11 @@
  <service name="download_url">
     <param name="protocol">https</param>
     <param name="host">storage.googleapis.com</param>
-    <param name="path">golang/go1.8.3.linux-amd64.tar.gz</param>
+    <param name="path">golang/go@GO_VERSION@.linux-amd64.tar.gz</param>
  </service>
  <service name="verify_file">
-    <param name="file">_service:download_url:go1.8.3.linux-amd64.tar.gz</param>
+    <param name="file">_service:download_url:go@GO_VERSION@.linux-amd64.tar.gz</param>
     <param name="verifier">sha256</param>
-    <param name="checksum">1862f4c3d3907e59b04a757cfda0ea7aa9ef39274af99a784f5be843c80c6772</param>
+    <param name="checksum">@GO_CHECKSUM@</param>
   </service>
 </services>

--- a/proxy/cc-proxy.spec-template
+++ b/proxy/cc-proxy.spec-template
@@ -4,7 +4,7 @@
 %global ORG clearcontainers
 %global PROJECT proxy
 %global IMPORTNAME %{DOMAIN}/%{ORG}/%{PROJECT}
-%global GO_VERSION 1.8.3
+%global GO_VERSION @GO_VERSION@
 
 %if 0%{?suse_version}
 %define LIBEXECDIR %{_libdir}

--- a/proxy/debian.rules-template
+++ b/proxy/debian.rules-template
@@ -5,13 +5,16 @@ export DEB_BUILD_OPTIONS=nocheck
 export PATH:=/usr/src/packages/BUILD/local/go/bin:$(PATH)
 export GOROOT:=/usr/src/packages/BUILD/local/go
 export GOPATH=/usr/src/packages/BUILD/go
+
+GO_VERSION=@GO_VERSION@
+
 %:
 	dh $@
 
 override_dh_auto_build:
 	mkdir -p /usr/src/packages/BUILD/local/
 	mkdir -p /usr/src/packages/BUILD/go/src/github.com/clearcontainers/
-	tar xzf /usr/src/packages/SOURCES/go1.8.3.linux-amd64.tar.gz -C /usr/src/packages/BUILD/local/
+	tar xzf /usr/src/packages/SOURCES/go$(GO_VERSION).linux-amd64.tar.gz -C /usr/src/packages/BUILD/local/
 	ln -s /usr/src/packages/BUILD/ /usr/src/packages/BUILD/go/src/github.com/clearcontainers/proxy
 	cd $(GOPATH)/src/github.com/clearcontainers/proxy && make VERSION=@VERSION_STRING@
 

--- a/proxy/update_proxy.sh
+++ b/proxy/update_proxy.sh
@@ -39,9 +39,13 @@ function template()
     sed -e "s/@VERSION@/$VERSION/g" \
         -e "s/@RELEASE@/$RELEASE/g" \
         -e "s/@HASH@/$short_hashtag/g" \
-        -e "s/@VERSION_STRING@/${VERSION}+git.${short_hashtag}/g" cc-proxy.spec-template > cc-proxy.spec
+        -e "s/@VERSION_STRING@/${VERSION}+git.${short_hashtag}/g" \
+        -e "s/@GO_VERSION@/$go_version/g" \
+        cc-proxy.spec-template > cc-proxy.spec
 
-    sed -e "s/@VERSION_STRING@/${VERSION}+git.${short_hashtag}/" debian.rules-template > debian.rules
+    sed -e "s/@VERSION_STRING@/${VERSION}+git.${short_hashtag}/" \
+        -e "s/@GO_VERSION@/$go_version/g" \
+        debian.rules-template > debian.rules
 
     sed -e "s/@VERSION@/$VERSION/g" \
         -e "s/@HASH@/$short_hashtag/g" \
@@ -54,9 +58,15 @@ function template()
     # which uses the version from versions.txt.
     # This will determine which source tarball will be retrieved from github.com
     if [ -n "$OBS_REVISION" ]; then
-        sed "s/@REVISION@/$OBS_REVISION/" _service-template > _service
+        sed -e "s/@REVISION@/$OBS_REVISION/" \
+            -e "s/@GO_VERSION@/$go_version/g" \
+            -e "s/@GO_CHECKSUM@/$go_checksum/" \
+            _service-template > _service
     else
-        sed "s/@REVISION@/$VERSION/"  _service-template > _service
+        sed -e "s/@REVISION@/$VERSION/" \
+            -e "s/@GO_VERSION@/$go_version/g" \
+            -e "s/@GO_CHECKSUM@/$go_checksum/" \
+            _service-template > _service
     fi
 }
 

--- a/runtime/_service-template
+++ b/runtime/_service-template
@@ -14,11 +14,11 @@
  <service name="download_url">
     <param name="protocol">https</param>
     <param name="host">storage.googleapis.com</param>
-    <param name="path">golang/go1.8.3.linux-amd64.tar.gz</param>
+    <param name="path">golang/go@GO_VERSION@.linux-amd64.tar.gz</param>
  </service>
  <service name="verify_file">
-    <param name="file">_service:download_url:go1.8.3.linux-amd64.tar.gz</param>
+    <param name="file">_service:download_url:go@GO_VERSION@.linux-amd64.tar.gz</param>
     <param name="verifier">sha256</param>
-    <param name="checksum">1862f4c3d3907e59b04a757cfda0ea7aa9ef39274af99a784f5be843c80c6772</param>
+    <param name="checksum">@GO_CHECKSUM@</param>
   </service>
 </services>

--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -4,7 +4,7 @@
 %global ORG clearcontainers
 %global PROJECT runtime
 %global IMPORTNAME %{DOMAIN}/%{ORG}/%{PROJECT}
-%global GO_VERSION 1.8.3
+%global GO_VERSION @GO_VERSION@
 
 %if 0%{?suse_version}
 %define LIBEXECDIR %{_libdir}

--- a/runtime/debian.rules-template
+++ b/runtime/debian.rules-template
@@ -7,13 +7,15 @@ export GOPATH=/usr/src/packages/BUILD/go
 export GOROOT=/usr/src/packages/BUILD/local/go
 export DH_OPTIONS
 
+GO_VERSION=@GO_VERSION@
+
 %:
 	dh $@
 
 override_dh_auto_build:
 	mkdir -p /usr/src/packages/BUILD/local/
 	mkdir -p /usr/src/packages/BUILD/go/src/github.com/clearcontainers/
-	tar xzf /usr/src/packages/SOURCES/go1.8.3.linux-amd64.tar.gz -C /usr/src/packages/BUILD/local
+	tar xzf /usr/src/packages/SOURCES/go$(GO_VERSION).linux-amd64.tar.gz -C /usr/src/packages/BUILD/local
 	ln -s /usr/src/packages/BUILD /usr/src/packages/BUILD/go/src/github.com/clearcontainers/runtime
 	cd $(GOPATH)/src/github.com/clearcontainers/runtime/; \
 	make PREFIX=/usr \

--- a/runtime/update_runtime.sh
+++ b/runtime/update_runtime.sh
@@ -46,10 +46,13 @@ function template()
 	    -e "s/@cc_image_version@/$image_obs_fedora_version/" \
 	    -e "s/@linux_container_version@/$linux_container_obs_fedora_version/" \
 	    -e "s/@qemu_lite_obs_fedora_version@/$qemu_lite_obs_fedora_version/g" \
+	    -e "s/@GO_VERSION@/$go_version/" \
 	    cc-runtime.spec-template > cc-runtime.spec
 
     sed -e "s/@VERSION@/$VERSION/" \
-	    -e "s/@HASH@/$short_hashtag/" debian.rules-template > debian.rules
+        -e "s/@HASH@/$short_hashtag/" \
+        -e "s/@GO_VERSION@/$go_version/" \
+        debian.rules-template > debian.rules
 
     sed -e "s/@VERSION@/$VERSION/g"\
 	    -e "s/@RELEASE@/$RELEASE/g" \
@@ -77,9 +80,15 @@ function template()
     # which uses the version from versions.txt.
     # This will determine which source tarball will be retrieved from github.com
     if [ -n "$OBS_REVISION" ]; then
-	    sed "s/@REVISION@/$OBS_REVISION/" _service-template > _service
+        sed -e "s/@REVISION@/$OBS_REVISION/" \
+            -e "s/@GO_VERSION@/$go_version/g" \
+            -e "s/@GO_CHECKSUM@/$go_checksum/" \
+            _service-template > _service
     else
-	    sed "s/@REVISION@/$VERSION/"  _service-template > _service
+        sed -e "s/@REVISION@/$VERSION/" \
+            -e "s/@GO_VERSION@/$go_version/g" \
+            -e "s/@GO_CHECKSUM@/$go_checksum/" \
+            _service-template > _service
     fi
 }
 

--- a/versions.txt
+++ b/versions.txt
@@ -9,6 +9,11 @@ clear_vm_kernel_version=4.9.60
 clear_vm_image_version=19490
 qemu_lite_version=2.7.1
 
+# Golang
+go_version=1.9.2
+# sha256 checksum for the go_version binary distribution ("go${go_version}.linux-amd64.tar.gz")
+go_checksum=de874549d9a8d8d8062be05808509c09a88a248e77ec14eb77453530829ac02b
+
 # OBS package versions
 # Versions matches the ones in the OBS stable release.
 # When making a new release of the runtime, this file


### PR DESCRIPTION
Right now, the go version is hardcoded in the scripts. This commit adds
a go_version in the versions.txt file with the latest go release
version. This variable is now used across projects in order to build
them with the same go version.

Fixes #206
