### PR TITLE
CI: Require two pullapprove acks

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -31,8 +31,9 @@ groups:
       - clear-containers
 
   approvers:
-    required: 1
+    required: 2
     users:
+      - amshinde
       - erick0z
       - gorozco1
       - grahamwhaley


### PR DESCRIPTION
Only allow a PR to be merged if two approvals are given.

Also, add an extra user to expand the list of approvers.

Fixes #217.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>