### PR TITLE
kernel: Add missing config and System.map to rpm packages

### DIFF
--- a/kernel/debian.control
+++ b/kernel/debian.control
@@ -11,3 +11,8 @@ Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends},
 Description: linux kernel optimised for container-like workloads.
  Linux kernel optimised for container-like workloads
+
+Package: linux-container-debug
+Architecture: amd64
+Description: Debug components for the linux-container package.
+ This package includes the kernel config and the kernel map.

--- a/kernel/debian.rules
+++ b/kernel/debian.rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 include /usr/share/dpkg/default.mk
 KernelDir=debian/linux-container/usr/share/clear-containers
+DebugDir=debian/linux-container-debug/usr/share/clear-containers
 KernelVer=${DEB_VERSION_UPSTREAM_REVISION}.container
 %:
 	dh $@
@@ -12,12 +13,14 @@ override_dh_auto_build:
 	make -s CONFIG_DEBUG_SECTION_MISMATCH=y -j8 ARCH=x86_64 all
 
 override_dh_auto_install:
+
 override_dh_auto_clean:
 
 override_dh_install:
 	dh_install
-	install -m 644 .config $(KernelDir)/config-$(KernelVer)
-	install -m 644 System.map $(KernelDir)/System.map-$(KernelVer)
+	mkdir -p $(DebugDir)
+	install -m 644 .config $(DebugDir)/config-$(KernelVer)
+	install -m 644 System.map $(DebugDir)/System.map-$(KernelVer)
 
 	cp arch/x86/boot/bzImage $(KernelDir)/vmlinuz-$(KernelVer)
 	chmod 755 $(KernelDir)/vmlinuz-$(KernelVer)

--- a/kernel/linux-container-debug.install
+++ b/kernel/linux-container-debug.install
@@ -1,0 +1,2 @@
+/usr/share/clear-containers/config-@KERNEL_VERSION@
+/usr/share/clear-containers/System.map-@KERNEL_VERSION@

--- a/kernel/linux-container.dsc-template
+++ b/kernel/linux-container.dsc-template
@@ -11,6 +11,10 @@ Debtransform-Tar: linux-@VERSION@.tar.xz
 
 Package: linux-container
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends},
 Description: linux kernel optimised for container-like workloads.
  Linux kernel optimised for container-like workloads
+
+Package: linux-container-debug
+Architecture: amd64
+Description: Debug components for the linux-container package.
+ This package includes the kernel config and the kernel map.

--- a/kernel/linux-container.install
+++ b/kernel/linux-container.install
@@ -1,0 +1,4 @@
+/usr/share/clear-containers/vmlinux.container
+/usr/share/clear-containers/vmlinuz.container
+/usr/share/clear-containers/vmlinuz-@KERNEL_VERSION@
+/usr/share/clear-containers/vmlinuz-@KERNEL_VERSION@

--- a/kernel/linux-container.spec-template
+++ b/kernel/linux-container.spec-template
@@ -63,6 +63,14 @@ Patch0209: 0209-HACK-9P-always-use-cached-inode-to-fill-in-v9fs_vfs_.patch
 %description
 The Linux kernel.
 
+%package debug
+Summary: Debug components for the linux-container package.
+Group: Default
+
+%description debug
+Debug components for the linux-container package.
+This package includes the kernel config and the kernel map.
+
 %prep
 %setup -q -n linux-@VERSION@
 
@@ -132,6 +140,9 @@ InstallKernel() {
     chmod 755 ${KernelDir}/vmlinux-$KernelVer
     ln -sf vmlinux-$KernelVer ${KernelDir}/vmlinux.container
 
+    cp .config "${KernelDir}/config-${KernelVer}"
+    cp System.map "${KernelDir}/System.map-${KernelVer}"
+
     rm -f %{buildroot}/usr/lib/modules/$KernelVer/build
     rm -f %{buildroot}/usr/lib/modules/$KernelVer/source
 }
@@ -146,3 +157,8 @@ rm -rf %{buildroot}/usr/lib/firmware
 /usr/share/clear-containers/vmlinux.container
 /usr/share/clear-containers/vmlinuz-%{kversion}
 /usr/share/clear-containers/vmlinuz.container
+
+%files debug
+%defattr(-,root,root,-)
+/usr/share/clear-containers/config-%{kversion}
+/usr/share/clear-containers/System.map-%{kversion}

--- a/kernel/update_kernel.sh
+++ b/kernel/update_kernel.sh
@@ -61,6 +61,8 @@ function template()
     sed "s/\@VERSION\@/$VERSION/g; s/\@RELEASE\@/$RELEASE/g" linux-container.spec-template > linux-container.spec
     sed "s/\@VERSION\@/$VERSION/g; s/\@RELEASE\@/$RELEASE/g" linux-container.dsc-template > linux-container.dsc
     sed "s/\@VERSION\@/$VERSION/g; s/\@KERNEL_SHA256\@/$kernel_sha256/g" _service-template > _service
+    sed "s/\@KERNEL_VERSION\@/${VERSION}-${RELEASE}.container/g" linux-container.install
+    sed "s/\@KERNEL_VERSION\@/${VERSION}-${RELEASE}.container/g" linux-container-debug.install
 }
 
 verify


### PR DESCRIPTION
RPM packages are missing kernel config and map files. This commit
ensures that rpm packages ship the missing files. Kernel config and map
are suffixed with the version of the kernel.

Fixes #216
