### PR TITLE
packages: Remove cc-oci-package mentions

### DIFF
--- a/proxy/cc-proxy.spec-template
+++ b/proxy/cc-proxy.spec-template
@@ -44,19 +44,19 @@ Overview
 %define _unpackaged_files_terminate_build 0
 
 %package bin
-Summary: bin components for the cc-oci-proxy package.
+Summary: bin components for the cc-proxy package.
 Group: Binaries
 Requires: cc-proxy-config
 
 %description bin
-bin components for the cc-oci-proxy package.
+bin components for the cc-proxy package.
 
 %package config
-Summary: config components for the cc-oci-proxy package.
+Summary: config components for the cc-proxy package.
 Group: Default
 
 %description config
-config components for the cc-oci-proxy package.
+config components for the cc-proxy package.
 
 %prep
 mkdir local

--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -53,19 +53,19 @@ Overview
 --------
 
 %package bin
-Summary: bin components for the cc-oci-runtime package.
+Summary: bin components for the cc-runtime package.
 Group: Binaries
 Requires: cc-runtime-config
 
 %description bin
-bin components for the cc-oci-runtime package.
+bin components for the cc-runtime package.
 
 %package config
-Summary: config components for the cc-oci-runtime package.
+Summary: config components for the cc-runtime package.
 Group: Default
 
 %description config
-config components for the cc-oci-runtime package.
+config components for the cc-runtime package.
 
 %prep
 mkdir local

--- a/shim/cc-shim.spec-template
+++ b/shim/cc-shim.spec-template
@@ -26,11 +26,11 @@ Overview
 --------
 
 %package bin
-Summary: bin components for the cc-oci-shim package.
+Summary: bin components for the cc-shim package.
 Group: Binaries
 
 %description bin
-bin components for the cc-oci-shim package.
+bin components for the cc-shim package.
 
 %prep
 %setup -q


### PR DESCRIPTION
This commit replaces cc-oci-"package" ocurrencies for their correct
value. e.g cc-oci-runtime -> cc-runtime.

Fixes #220

Signed-off-by: Erick Cardona <erick.cardona.ruiz@intel.com>