### PR TITLE
runtime: Install cc-ksm-throttler as dependency

### DIFF
--- a/runtime/cc-runtime.dsc-template
+++ b/runtime/cc-runtime.dsc-template
@@ -13,7 +13,7 @@ Package: cc-runtime
 Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime-bin, cc-runtime-config, qemu-lite (>= @qemu_lite_obs_ubuntu_version@),
                           clear-containers-image (>= @cc_image_version@), linux-container (>= @linux_container_version@),
-			  cc-proxy (>= @cc_proxy_version@), cc-shim (>= @cc_shim_version@)
+			  cc-proxy (>= @cc_proxy_version@), cc-shim (>= @cc_shim_version@), cc-ksm-throttler(>= @cc_ksm_throttler_version@)
 Provides: cc-oci-runtime
 Conflicts: cc-oci-runtime
 Replaces: cc-oci-runtime

--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -34,6 +34,7 @@ Requires: clear-containers-image >= @cc_image_version@
 Requires: linux-container >= @linux_container_version@
 Requires: cc-proxy >= @cc_proxy_version@
 Requires: cc-shim >= @cc_shim_version@
+Requires: cc-ksm-throttler >= @cc_ksm_throttler_version@
 
 Conflicts: cc-oci-runtime
 Conflicts: cc-oci-runtime-bin

--- a/runtime/debian.control-template
+++ b/runtime/debian.control-template
@@ -11,7 +11,7 @@ Package: cc-runtime
 Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, cc-runtime-bin, cc-runtime-config, qemu-lite (>= @qemu_lite_obs_ubuntu_version@),
                             clear-containers-image (>= @cc_image_version@), linux-container (>= @linux_container_version@),
-			    cc-proxy (>= @cc_proxy_version@), cc-shim (>= @cc_shim_version@)
+			    cc-proxy (>= @cc_proxy_version@), cc-shim (>= @cc_shim_version@), cc-ksm-throttler (>= @cc_ksm_throttler_version@)
 Provides: cc-oci-runtime
 Conflicts: cc-oci-runtime
 Replaces: cc-oci-runtime

--- a/runtime/update_runtime.sh
+++ b/runtime/update_runtime.sh
@@ -47,6 +47,7 @@ function template()
 	    -e "s/@linux_container_version@/$linux_container_obs_fedora_version/" \
 	    -e "s/@qemu_lite_obs_fedora_version@/$qemu_lite_obs_fedora_version/g" \
 	    -e "s/@GO_VERSION@/$go_version/" \
+	    -e "s/@cc_ksm_throttler_version@/$ksm_throttler_version/" \
 	    cc-runtime.spec-template > cc-runtime.spec
 
     sed -e "s/@VERSION@/$VERSION/" \
@@ -63,6 +64,7 @@ function template()
 	    -e "s/@qemu_lite_version@/$qemu_lite_obs_ubuntu_version/" \
 	    -e "s/@linux_container_version@/$linux_container_obs_ubuntu_version/" \
 	    -e "s/@qemu_lite_obs_ubuntu_version@/$qemu_lite_obs_ubuntu_version/" \
+	    -e "s/@cc_ksm_throttler_version@/$ksm_throttler_version/" \
 	    cc-runtime.dsc-template > cc-runtime.dsc
 
     sed -e "s/@VERSION@/$VERSION/" \
@@ -73,6 +75,7 @@ function template()
 	    -e "s/@qemu_lite_version@/$qemu_lite_obs_ubuntu_version/" \
 	    -e "s/@linux_container_version@/$linux_container_obs_ubuntu_version/" \
 	    -e "s/@qemu_lite_obs_ubuntu_version@/$qemu_lite_obs_ubuntu_version/"  \
+	    -e "s/@cc_ksm_throttler_version@/$ksm_throttler_version/" \
 	    debian.control-template > debian.control
 
     # If OBS_REVISION is not empty, which means a branch or commit ID has been passed as argument,


### PR DESCRIPTION
cc-ksm-throttler should be installed as dependency when installing cc-runtime.
This commit adds cc-ksm-throttler as dependecy to the cc-runtime spec and dsc files.

Fixes #225

Signed-off-by: Erick Cardona <erick.cardona.ruiz@intel.com>