### PR TITLE
runtime: Fix qemu-lite dependency on Fedora 27

### DIFF
--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -30,6 +30,10 @@ BuildRequires: openSUSE-release
 Requires: cc-runtime-bin
 Requires: cc-runtime-config
 %{!?el7 || !?suse_version:Requires: qemu-lite >= @qemu_lite_obs_fedora_version@ }
+%if 0%{?fedora} >= 27
+Requires: qemu-lite >= @qemu_lite_obs_fedora_version@
+%endif
+
 Requires: clear-containers-image >= @cc_image_version@
 Requires: linux-container >= @linux_container_version@
 Requires: cc-proxy >= @cc_proxy_version@


### PR DESCRIPTION
cc-runtime installs qemu-lite as dependency if the target distro is NOT
RHEL or any SUSE version. Fedora 27 falls into this conditional for some
reason. This commit explicitly adds qemu-lite as requirement when
installing on Fedora systems >= 27.

Fixes #233

Signed-off-by: Erick Cardona <erick.cardona.ruiz@intel.com>