### PR TITLE
proxy: Remove systemd service/socket files

### DIFF
--- a/proxy/cc-proxy.dsc-template
+++ b/proxy/cc-proxy.dsc-template
@@ -12,6 +12,9 @@ Debtransform-Tar: cc-proxy-@VERSION@+git.@HASH@.tar.gz
 Package: cc-proxy
 Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
+Provides: cc-proxy-config
+Conflicts: cc-proxy-config
+Replaces: cc-proxy-config
 Description:
  cc-proxy works alongside the Clear Containers runtime and shim to provide a VM-based OCI runtime solution.
  cc-proxy is a daemon offering access to the hyperstart VM agent to both the runtime and shim processes.

--- a/proxy/cc-proxy.spec-template
+++ b/proxy/cc-proxy.spec-template
@@ -25,12 +25,13 @@ Group    : Development/Tools
 License  : Apache-2.0
 
 Requires: cc-proxy-bin
-Requires: cc-proxy-config
 
 %if 0%{?fedora} >= 20 || 0%{?centos} >= 7 || 0%{?rhel} >= 7 || 0%{?oraclelinux} >= 7
 Requires: clear-containers-selinux
 %endif
 
+Conflicts: cc-proxy-config
+Obsoletes: cc-proxy-config
 
 %description
 .. contents::
@@ -46,17 +47,9 @@ Overview
 %package bin
 Summary: bin components for the cc-proxy package.
 Group: Binaries
-Requires: cc-proxy-config
 
 %description bin
 bin components for the cc-proxy package.
-
-%package config
-Summary: config components for the cc-proxy package.
-Group: Default
-
-%description config
-config components for the cc-proxy package.
 
 %prep
 mkdir local
@@ -74,13 +67,19 @@ ln -s %{_builddir}/%{name}-%{version} $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 cd $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 make LIBEXECDIR=%{LIBEXECDIR} VERSION=@VERSION_STRING@
 
-%check
-export http_proxy=http://127.0.0.1:9/
-export https_proxy=http://127.0.0.1:9/
-export no_proxy=localhost
+%clean
+echo "Clean build root"
+rm -rf %{buildroot}
 
 %install
 make install DESTDIR=%{buildroot} LIBEXECDIR=%{LIBEXECDIR} VERSION=@VERSION_STRING@
+
+%post
+# ensure that *all* the following commands run.
+set +e
+systemctl stop cc-proxy.socket
+systemctl stop cc-proxy.service
+systemctl daemon-reload
 
 %files
 %defattr(-,root,root,-)
@@ -89,8 +88,3 @@ make install DESTDIR=%{buildroot} LIBEXECDIR=%{LIBEXECDIR} VERSION=@VERSION_STRI
 %defattr(-,root,root,-)
 %{LIBEXECDIR}/clear-containers
 %{LIBEXECDIR}/clear-containers/cc-proxy
-
-%files config
-%defattr(-,root,root,-)
-/usr/lib/systemd/system/cc-proxy.service
-/usr/lib/systemd/system/cc-proxy.socket

--- a/proxy/debian.postinst
+++ b/proxy/debian.postinst
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Ensure that *all* the following commands run.
+set +e
+
+systemctl stop cc-proxy.socket
+systemctl stop cc-proxy.service
+[ -e /usr/lib/systemd/system/cc-proxy.service ] && rm /usr/lib/systemd/system/cc-proxy.service || true
+[ -e /usr/lib/systemd/system/cc-proxy.socket ] && rm /usr/lib/systemd/system/cc-proxy.socket || true
+systemctl daemon-reload

--- a/proxy/update_proxy.sh
+++ b/proxy/update_proxy.sh
@@ -18,7 +18,7 @@ APPORT_HOOK="source_cc-proxy.py"
 BUILD_DISTROS=(Fedora_26 xUbuntu_16.04)
 
 GENERATED_FILES=(cc-proxy.spec cc-proxy.dsc debian.control debian.rules _service)
-STATIC_FILES=(debian.changelog debian.compat)
+STATIC_FILES=(debian.changelog debian.compat debian.postinst)
 
 COMMIT=false
 BRANCH=false


### PR DESCRIPTION
Due to recent changes to clearcontainers/proxy and the introduction of
kata-containers/ksm-throttler, the systemd service and socket file from
the cc-proxy package are no longer required as mentioned in the
following issue: #198.
This commit removes those files using post-install scripts.

Fixes #199

Signed-off-by: Erick Cardona <erick.cardona.ruiz@intel.com>