### PR TITLE
release-tools: use sudo to create rootfs and image

### DIFF
--- a/release-tools/release_image_github.sh
+++ b/release-tools/release_image_github.sh
@@ -58,8 +58,8 @@ build_image() {
 	export USE_DOCKER=1
 	export WORKDIR="${workdir_builder}"
 
-	AGENT_VERSION="${agent_version}" OS_VERSION="${os_version}" make rootfs
-	make image
+	AGENT_VERSION="${agent_version}" OS_VERSION="${os_version}" sudo -E make rootfs
+	sudo -E make image
 }
 
 build_release_tool() {


### PR DESCRIPTION
If a user does not have access to docker,
release_image_github.sh will fail.
This commit adds sudo to the make rootfs and make
image calls (which use docker) in the
release_image_github.sh script

Fixes: #276.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>