### PR TITLE
scripts: Add reason tags to hypervisor config script

### DIFF
--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -104,6 +104,8 @@ show_array()
 # Entry point
 main()
 {
+    arch=$(arch)
+
     typeset -a qemu_options
     multi_line=no
 
@@ -232,7 +234,7 @@ main()
     # Other options
 
     # 64-bit only
-    qemu_options+=(--target-list=x86_64-softmmu)
+    [ "$arch" = x86_64 ] && qemu_options+=("--target-list=${arch}-softmmu")
 
     _qemu_cflags=""
 
@@ -283,7 +285,7 @@ main()
     unset _qemu_ldflags
 
     # Where to install qemu libraries
-    qemu_options+=(--libdir=/usr/lib64/${hypervisor})
+    [ "$arch" = x86_64 ] && qemu_options+=(--libdir=/usr/lib64/${hypervisor})
 
     # Where to install qemu helper binaries
     qemu_options+=(--libexecdir=/usr/libexec/${hypervisor})

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -68,24 +68,24 @@ EOT
 # Arguments:
 #
 # $1: *Name* of array variable (no leading '$'!!)
-# $2: any value (optional)
+# $2: (optional) "multi" - show values across multiple lines.
+#    Any other value results in the options being displayed on
+#    a single line.
 show_array()
 {
     local -n _array="$1"
-
-    local show_multi_line=no
-
-    [ -n "$2" ] && show_multi_line=yes
-
-    if [ "$show_multi_line" = no ]; then
-        echo "${_array[@]}"
-        return
-    fi
+    local action="$2"
 
     local -i size="${#_array[*]}"
     local -i i=1
     local suffix
     local elem
+
+    if [ "$action" = "multi" ]; then
+        echo "${_array[@]}"
+        return
+    fi
+
 
     for elem in "${_array[@]}"
     do
@@ -97,6 +97,7 @@ show_array()
         fi
 
         printf '%s%s\n' "$elem" "$suffix"
+
         i+=1
     done
 }
@@ -107,7 +108,7 @@ main()
     arch=$(arch)
 
     typeset -a qemu_options
-    multi_line=no
+    action=""
 
     while getopts "hm" opt
     do
@@ -118,7 +119,7 @@ main()
                 ;;
 
             m)
-                multi_line="yes"
+                action="multi"
                 ;;
         esac
     done
@@ -293,12 +294,7 @@ main()
     # Where to install data files
     qemu_options+=(--datadir=/usr/share/${hypervisor})
 
-    if [ "$multi_line" = yes ]
-    then
-        show_array qemu_options true
-    else
-        show_array qemu_options
-    fi
+    show_array qemu_options "$action"
 }
 
 main $@

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2017-2018 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ Usage:
 
 Options:
 
+    -h : Display this help.
     -m : Display options one per line (includes continuation characters).
 
 Example:


### PR DESCRIPTION
Update the hypervisor configuration script so that it now records one
or more tags for each hypervisor configuration option specified. These
tags explain why each option was chosen.

Also added a new `-d` CLI option to dump out all options and their
corresponding tags.

Fixes #282.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>