### PR TITLE
runtime: Fix generating wrong config paths

### DIFF
--- a/runtime/cc-runtime.spec-template
+++ b/runtime/cc-runtime.spec-template
@@ -89,7 +89,7 @@ ln -s $HOME/rpmbuild/BUILD/cc-runtime-%{version} $HOME/rpmbuild/BUILD/go/src/%{I
 cd $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 make PREFIX=/usr \
    LIBEXECDIR=%{LIBEXECDIR} \
-   SYSCONFDIR=/usr/share/defaults \
+   SYSCONFDIR=/etc \
    LOCALSTATEDIR=/var \
    SHAREDIR=/usr/share \
    VERSION=@VERSION@ \

--- a/runtime/debian.rules-template
+++ b/runtime/debian.rules-template
@@ -21,7 +21,7 @@ override_dh_auto_build:
 	ln -s /usr/src/packages/BUILD /usr/src/packages/BUILD/go/src/github.com/clearcontainers/runtime
 	cd $(GOPATH)/src/github.com/clearcontainers/runtime/; \
 	make PREFIX=/usr \
-		SYSCONFDIR=/usr/share/defaults \
+		SYSCONFDIR=/etc \
 		LOCALSTATEDIR=/var \
 		SHAREDIR=/usr/share \
 		VERSION=@VERSION@ \


### PR DESCRIPTION
I don't know why you changed it at 82ab3bbb9b71c77dfbb7dd3a1b790ebe9e265a1e, but it makes runtime don't search directory /etc/clear-containers/ anymore, and run "/usr/bin/cc-runtime --cc-show-default-config-paths" shows

```
/usr/share/defaults/clear-containers/configuration.toml
/usr/share/defaults/clear-containers/configuration.toml
```

regards